### PR TITLE
Clear apt-get cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && apt-get install -y \
         libcurl4-openssl-dev \
     && docker-php-ext-install iconv mcrypt mbstring json intl pdo pdo_mysql curl gd \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install gd
+    && docker-php-ext-install gd \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN a2enmod rewrite headers ssl
 


### PR DESCRIPTION
Clear apt-get cache as part of the install-and-configure `RUN` line to reduce size, and increase cacheability